### PR TITLE
Upgrade to newer version of d3graph

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -2,7 +2,7 @@ import streamlit as st
 from streamlit_d3graph import d3graph
 
 
-@st.experimental_memo
+@st.cache_data
 def init_graph():
     # Initialize
     d3 = d3graph()
@@ -15,33 +15,33 @@ def init_graph():
     return d3, adjmat, df, label, node_size
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_one(_d3, adjmat, df, label, node_size):
     d3.graph(adjmat)
     d3.set_node_properties(color=df["label"].values)
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_two(_d3, adjmat, df, label, node_size):
     d3.set_node_properties(label=label, color=label, cmap="Set1")
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_three(_d3, adjmat, df, label, node_size):
     d3.set_node_properties(color=label, size=node_size)
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_four(_d3, adjmat, df, label, node_size):
     d3.set_edge_properties(edge_distance=100)
     d3.set_node_properties(color=node_size, size=node_size)
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_five(adjmat, df, label, node_size):
     d3 = d3graph(charge=1000)
     d3.graph(adjmat)
@@ -49,7 +49,7 @@ def graph_five(adjmat, df, label, node_size):
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_six(adjmat, df, label, node_size):
     d3 = d3graph(collision=1, charge=250)
     d3.graph(adjmat)
@@ -59,7 +59,7 @@ def graph_six(adjmat, df, label, node_size):
     return d3
 
 
-@st.experimental_memo
+@st.cache_data
 def graph_seven(adjmat, df, label, node_size):
     d3 = d3graph(collision=1, charge=250)
     d3.graph(adjmat)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
-streamlit
+streamlit==1.27.0
 streamlit-d3graph==1.0.3
-scipy
-scikit-learn
+scipy==1.11.2
+scikit-learn==1.3.1

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,2 +1,4 @@
 streamlit
-streamlit-d3graph==1.0.2
+streamlit-d3graph==1.0.3
+scipy
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding='utf8') as fh:
 
 setuptools.setup(
     name="streamlit-d3graph",
-    version="1.0.2",
+    version="1.0.3",
     author="Snehan Kekre",
     author_email="contact@snehankekre.com",
     description="A simple component to display d3graph network graphs in Streamlit apps.",
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/snehankekre/streamlit-d3graph",
-    install_requires=["d3graph>=2.0.1", "streamlit", "seaborn"],
+    install_requires=["d3graph>=2.4.10", "streamlit", "seaborn"],
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[

--- a/streamlit_d3graph/__init__.py
+++ b/streamlit_d3graph/__init__.py
@@ -1,9 +1,5 @@
-import streamlit as st
 import streamlit.components.v1 as components
 from d3graph import d3graph as OrigD3graph
-import time
-import os
-import io
 
 from d3graph.d3graph import *
 
@@ -12,65 +8,7 @@ from d3graph.d3graph import *
 ## to display d3graph in Streamlit apps
 
 class d3graph(OrigD3graph):
-    @classmethod
-    def __init__(self, collision=0.5, charge=250, slider=[None, None], verbose=20):
-        library_compatibility_checks()
-        # Set the logger
-        set_logger(verbose=verbose)
-        # Setup configurations
-        self.config = {}
-        self.config["network_collision"] = collision
-        self.config["network_charge"] = charge * -1
-        self.config["slider"] = slider
-        # Set path locations
-        self.config["curpath"] = os.path.dirname(os.path.abspath(__file__))
-        self.config["d3_library"] = os.path.abspath(
-            os.path.join(self.config["curpath"], "d3js/d3.v3.js")
-        )
-        self.config["d3_script"] = os.path.abspath(
-            os.path.join(self.config["curpath"], "d3js/d3graphscript.js")
-        )
-        self.config["css"] = os.path.abspath(
-            os.path.join(self.config["curpath"], "d3js/style.css")
-        )
-
-    @classmethod
-    def write_html(self, json_data):
-        """Write html.
-        Parameters
-        ----------
-        json_data : json file
-            json file to embed in html.
-
-        Returns
-        -------
-        io.BytesIO.getvalue
-            html file.
-        """
-        self.content = {
-            "json_data": json_data,
-            "title": self.config["network_title"],
-            "width": self.config["figsize"][0],
-            "height": self.config["figsize"][1],
-            "charge": self.config["network_charge"],
-            "edge_distance": self.config["edge_distance"],
-            "min_slider": self.config["slider"][0],
-            "max_slider": self.config["slider"][1],
-            "directed": self.config["directed"],
-            "collision": self.config["network_collision"],
-        }
-        self.jinja_env = Environment(
-            loader=PackageLoader(package_name="d3graph", package_path="d3js")
-        )
-        self.index_template = self.jinja_env.get_template("index.html.j2")
-
-        # Write to in-memory buffer instead of file in /tmp
-        with io.BytesIO() as buffer:
-            buffer.write(self.index_template.render(self.content).encode())
-
-            return buffer.getvalue()
-
-    def show(self, figsize=(800, 800), title="d3graph", filepath=io.BytesIO()):
+    def show(self, figsize=(800, 800), title="d3graph", *args, **kwargs):
         """Build and show the graph.
 
         Parameters
@@ -95,23 +33,10 @@ class d3graph(OrigD3graph):
         >>> d3.show()
 
         """
-        time.sleep(0.5)
-        self.config["figsize"] = figsize
-        self.config["network_title"] = title
-
-        self.config["filepath"] = filepath
-
-        # Create dataframe from co-occurence matrix
-        self.G = make_graph(self.node_properties, self.edge_properties)
-        # Make slider
-        self.setup_slider()
-        # Create json
-        json_data = json_create(self.G)
-        # Create html with json file embedded
-        self.buffer = d3graph.write_html(json_data)
 
         return components.html(
-            self.buffer,
+            # Create html with json file embedded
+            super().show(figsize, title, *args, filepath=None, **kwargs),
             height=self.config["figsize"][1],
             width=self.config["figsize"][0],
         )


### PR DESCRIPTION
# D3graph library upgrade

1. streamlit-d3graph is no longer working with newer versions of D3graph library. It's because the newer version of d3graph changed their jinja template and it's no longer compatible with the code
2. With changes of d3graph it's possible now to re-use more parts and simplify the streamlit wrapper. 
3. Example has been updated - newer version of d3graph requires few extra libraries for using the examples (`scipy`, `scikit-learn`) 